### PR TITLE
Bump version to 0.43

### DIFF
--- a/ctris.h
+++ b/ctris.h
@@ -15,7 +15,7 @@
 #include <limits.h>
 #include <time.h>
 
-#define VERSION "v0.42" // version info
+#define VERSION "v0.43" // version info
 #define HEIGHT 24 // height of the screen
 #define WIDTH 80 // width of the screen
 #define BOARD_HEIGHT (HEIGHT - 5) // height of the board


### PR DESCRIPTION
Hello. I was building ctris for T2 Linux (information about package: https://t2sde.org/packages/ctris) and I noticed that ctris 0.43 still has version info set to 0.42. I don't know when you'll plan to release next version, if ever, so I didn't change the macro preemptively to something like 0.43.1 or 0.44.

Nice tetris clone btw.